### PR TITLE
:bug: Fix broken navigation link 

### DIFF
--- a/recipes/chknTacoCass.html
+++ b/recipes/chknTacoCass.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="/odin-recipes/" target="_blank">Home</a>
+            <a href="https://logan-tolbert.github.io/odin-recipes/" target="_blank">Home</a>
         </nav>
 
         <h1>Chicken Taco Casserole</h1>

--- a/recipes/chknTacoCass.html
+++ b/recipes/chknTacoCass.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="/index.html" target="_blank">Home</a>
+            <a href="odin-recipes/index.html" target="_blank">Home</a>
         </nav>
 
         <h1>Chicken Taco Casserole</h1>

--- a/recipes/chknTacoCass.html
+++ b/recipes/chknTacoCass.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="../index.html" target="_blank">Home</a>
+            <a href="/" target="_blank">Home</a>
         </nav>
 
         <h1>Chicken Taco Casserole</h1>

--- a/recipes/chknTacoCass.html
+++ b/recipes/chknTacoCass.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="/" target="_blank">Home</a>
+            <a href="/odin-recipes/" target="_blank">Home</a>
         </nav>
 
         <h1>Chicken Taco Casserole</h1>

--- a/recipes/chknTacoCass.html
+++ b/recipes/chknTacoCass.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="odin-recipes/index.html" target="_blank">Home</a>
+            <a href="../index.html" target="_blank">Home</a>
         </nav>
 
         <h1>Chicken Taco Casserole</h1>

--- a/recipes/salmonSalad.html
+++ b/recipes/salmonSalad.html
@@ -11,7 +11,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="/index.html" target="_blank">Home</a>
+            <a href="https://logan-tolbert.github.io/odin-recipes/" target="_blank">Home</a>
         </nav>
 
         <h1>Greek Yogurt Salmon Salad</h1>

--- a/recipes/stroganoff.html
+++ b/recipes/stroganoff.html
@@ -11,7 +11,7 @@
     <header>
         <nav>
             <h2>Odin Recipies</h2>
-            <a href="/index.html" target="_blank">Home</a>
+            <a href="https://logan-tolbert.github.io/odin-recipes/" target="_blank">Home</a>
         </nav>
 
         <h1>Ground Beef Stroganoff</h1>


### PR DESCRIPTION
If the link to Home was clicked on all recipe pages the browser would return a 404 error message.
Updated the path to index.html in all html files within the recipe directory.